### PR TITLE
Fix usage with Cloudflare Access Service Tokens

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,12 +97,6 @@ func authHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		return
 	}
 
-	// email is required in claims
-	if claims.Email == "" {
-		write(w, http.StatusUnauthorized, "No email in JWT claims")
-		return
-	}
-
 	// Request is good to go
 	w.Header().Set("X-Auth-User", claims.Email)
 	write(w, http.StatusOK, "OK!")


### PR DESCRIPTION
This library currently doesn't work when using Cloudflare access service tokens.

This is because emails aren't passed in via the JWT token. 

I've removed the code for validating the existence of an email. I don't see why this check should take place... if the application wants to use the email claim, it can still be passed into the X-Auth-User header... if not.. it will just be empty.  

This is an example of a payload when using Access tokens:
```
{
  "aud": "<audience>",
  "exp": 1598073284,
  "iss": "https://foo.cloudflareaccess.com",
  "common_name": "<access-id>.access",
  "iat": 1595445284,
  "sub": ""
}
```